### PR TITLE
Use a common context when loading custom screen and plugins

### DIFF
--- a/abacura/abacura.py
+++ b/abacura/abacura.py
@@ -49,7 +49,7 @@ class Abacura(App):
 
     def create_session(self, name: str) -> None:
         """Create a session"""
-        with Context(all=self.sessions, config=self.config, abacura=self):
+        with Context(config=self.config, abacura=self):
             self.sessions[name] = Session(name)
         self.session = name
 


### PR DESCRIPTION
Removed unused Session.all
Moved Session instance variables into __init__ , injected variables stay at class level for Serum