### PR TITLE
Added #ticker --list, fix unregistration bug

### DIFF
--- a/abacura-core/abacura/plugins/actions/__init__.py
+++ b/abacura-core/abacura/plugins/actions/__init__.py
@@ -50,7 +50,7 @@ class ActionManager:
         self.actions: PriorityQueue = PriorityQueue()
 
     def register_object(self, obj: object):
-        self.unregister_object(obj)  # prevent duplicates
+        # self.unregister_object(obj)  # prevent duplicates
         for name, member in inspect.getmembers(obj, callable):
             if hasattr(member, "action_pattern"):
                 act = Action(pattern=getattr(member, "action_pattern"), callback=member, source=obj,

--- a/abacura-core/abacura/plugins/events/__init__.py
+++ b/abacura-core/abacura/plugins/events/__init__.py
@@ -45,7 +45,7 @@ class EventManager:
         self.events: Dict[str, PriorityQueue] = {}
 
     def register_object(self, obj: object):
-        self.unregister_object(obj)  # prevent duplicates
+        # self.unregister_object(obj)  # prevent duplicates
 
         # Look for listeners in the plugin
         for member_name, member in inspect.getmembers(obj, callable):

--- a/abacura-core/abacura/plugins/scripts/__init__.py
+++ b/abacura-core/abacura/plugins/scripts/__init__.py
@@ -40,7 +40,7 @@ class ScriptManager:
         self.scripts: Dict[str, Script] = {}
 
     def register_object(self, obj: object):
-        self.unregister_object(obj)  # prevent duplicates
+        # self.unregister_object(obj)  # prevent duplicates
         for name, member in inspect.getmembers(obj, callable):
             if hasattr(member, "script_name"):
                 s = Script(source=obj, script_fn=member, name=getattr(member, "script_name"), session=self.session)

--- a/abacura-core/abacura/plugins/session/helper.py
+++ b/abacura-core/abacura/plugins/session/helper.py
@@ -13,7 +13,7 @@ class PluginSession(Plugin):
     def __init__(self):
         super().__init__()
         if self.session.ring_buffer:
-            self.add_ticker(1, self.session.ring_buffer.commit)
+            self.add_ticker(1, self.session.ring_buffer.commit, name="ring-autocommit")
 
     """Session specific commands"""
     @command(name="echo")

--- a/abacura-core/abacura/plugins/tickers/__init__.py
+++ b/abacura-core/abacura/plugins/tickers/__init__.py
@@ -41,7 +41,7 @@ class TickerManager:
         self.tickers: List[Ticker] = []
 
     def register_object(self, obj: object):
-        self.unregister_object(obj)  # prevent duplicates
+        # self.unregister_object(obj)  # prevent duplicates
         for name, member in inspect.getmembers(obj, callable):
             if hasattr(member, "ticker_seconds"):
                 t = Ticker(source=obj, callback=member, seconds=getattr(member, "ticker_seconds"),

--- a/abacura-core/abacura/plugins/tickers/helper.py
+++ b/abacura-core/abacura/plugins/tickers/helper.py
@@ -2,18 +2,46 @@ from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING
+from rich.table import Table
 
 from abacura.plugins import Plugin, command, CommandError
 
 if TYPE_CHECKING:
     pass
 
-
 class TickerCommand(Plugin):
 
+    def show_tickers(self):
+        tbl = Table(title="All tickers")
+        tbl.add_column("Name")
+        tbl.add_column("Callback")
+        tbl.add_column("Source")
+        tbl.add_column("Repeats", justify="right")
+        tbl.add_column("Seconds", justify="right")
+        tbl.add_column("Next Tick")
+
+        for ticker in self.director.ticker_manager.tickers:
+            tbl.add_row(ticker.name, ticker.callback.__qualname__, ticker.source.__class__.__name__,
+                        str(ticker.repeats), format(ticker.seconds, "7.3f"), str(ticker.next_tick))
+
+        self.output(tbl)
+
     @command
-    def ticker(self, name: str, message: str = '', seconds: float = 0, repeats: int = -1, delete: bool = False):
+    def ticker(self, name: str = '', message: str = '', seconds: float = 0, repeats: int = -1,
+               delete: bool = False, _list: bool = False):
         """Create/delete a ticker"""
+
+        if _list:
+            self.show_tickers()
+            return
+
+        if not name:
+            raise CommandError("Must specify ticker name")
+
+        if delete:
+            self.remove_ticker(name)
+            return
+
         if not message:
             raise CommandError("Must specify a message")
 
@@ -22,8 +50,6 @@ class TickerCommand(Plugin):
 
         # always remove an existing ticker with this name
         self.remove_ticker(name)
-        if delete:
-            return
 
         self.add_ticker(seconds=seconds, callback_fn=partial(self.session.output, msg=message),
                         repeats=repeats, name=name)

--- a/abacura-kallisti/abacura_kallisti/plugins/__init__.py
+++ b/abacura-kallisti/abacura_kallisti/plugins/__init__.py
@@ -83,7 +83,7 @@ class LOKPlugin(Plugin):
         if vnum in self.world.rooms:
             return self.world.rooms[vnum]
 
-        raise CommandError(f'Unknown room [{submitted_value}]')
+        raise CommandError(f"Unknown room '{submitted_value}'")
 
 
 _WIDGETS_LAZY_LOADING_CACHE: dict[str, type[Widget]] = {}


### PR DESCRIPTION
Use CommandArgumentError instead of AttributeError in commands so we can get tracebacks for actual AttributeErrors Do not auto unregister everything to prevent duplicates as it prevents calling self.add_ticker(), self.add_action(), etc