### PR TITLE
scroll to end upon resizing RichLog

### DIFF
--- a/abacura-core/abacura/mud/session.py
+++ b/abacura-core/abacura/mud/session.py
@@ -300,7 +300,7 @@ class Session(BaseSession):
             self.tl.markup = markup
             self.tl.highlight = highlight
 
-            scroll_end = self.tl.scroll_offset.y >= self.tl.virtual_size.height - self.tl.content_size.height
+            scroll_end = self.tl.viewing_end()
 
             if ansi:
                 self.tl.write(Text.from_ansi(message.message))

--- a/abacura-kallisti/abacura_kallisti/screens.py
+++ b/abacura-kallisti/abacura_kallisti/screens.py
@@ -82,10 +82,12 @@ class KallistiScreen(SessionScreen):
     def action_toggle_commslog(self) -> None:
         commslog = self.query_one("#commslog")
         commslog.display = not commslog.display
+        self.refresh()
 
     def action_toggle_debug(self) -> None:
         debugger = self.query_one("#debugger")
         debugger.display = not debugger.display
+        self.refresh()
 
     def action_toggle_map(self) -> None:
         def reset_mapkey():


### PR DESCRIPTION
refresh after toggling display of commslog / debuglog to ensure we get a resize event